### PR TITLE
Add responsive hamburger navigation to header

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,6 +22,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/assets",
+                "output": "assets"
               }
             ],
             "styles": [
@@ -79,6 +84,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "src/assets",
+                "output": "assets"
               }
             ],
             "styles": [

--- a/src/app/header/header.css
+++ b/src/app/header/header.css
@@ -1,109 +1,155 @@
 .header {
-    background: linear-gradient(to right, #0e4a87, #4f46e5); /* from-blue-600 to-indigo-700 */
+    background: linear-gradient(to right, #0e4a87, #4f46e5);
     color: #fff;
-    padding: 1.5rem; /* p-6 */
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); /* shadow-xl */
-    width: auto; /* w-full */
+    padding: 1.5rem;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 .header-nav {
     display: flex;
-    flex-direction: column; /* flex-col */
-    justify-content: space-between;
+    flex-wrap: wrap;
     align-items: center;
-    max-width: 72rem; /* max-w-7xl - Ajustado a 72rem para consistencia */
-    margin-left: auto;
-    margin-right: auto;
+    justify-content: space-between;
+    gap: 1rem;
+    max-width: 72rem;
+    margin: 0 auto;
 }
 
-@media (min-width: 768px) { /* md breakpoint */
-    .header-nav {
-        flex-direction: row; /* md:flex-row */
+.brand-area {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 1rem;
+}
+
+@media (min-width: 768px) {
+    .brand-area {
+        width: auto;
+        gap: 1.5rem;
     }
 }
 
 .brand-logo {
-    font-size: 1.875rem; /* text-3xl */
-    font-weight: 800; /* font-extrabold */
-    margin-bottom: 1rem; /* mb-4 */
-    transition: transform 0.3s ease-in-out; /* transition duration-300 ease-in-out */
-    cursor: pointer;
-}
-
-@media (min-width: 768px) { /* md breakpoint */
-    .brand-logo {
-        margin-bottom: 0; /* md:mb-0 */
-    }
+    display: inline-flex;
+    transition: transform 0.3s ease-in-out;
 }
 
 .brand-logo:hover {
-    transform: scale(1.05); /* hover:scale-105 */
+    transform: scale(1.05);
+}
+
+.menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: rgba(15, 23, 42, 0.15);
+    color: inherit;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+    background: rgba(15, 23, 42, 0.3);
+    border-color: rgba(255, 255, 255, 0.8);
+    transform: scale(1.05);
+}
+
+.menu-toggle svg {
+    width: 1.5rem;
+    height: 1.5rem;
 }
 
 .nav-links {
-    display: flex;
-    flex-direction: column; /* flex-col */
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
     list-style: none;
     padding: 0;
     margin: 0;
-    font-size: 1.125rem; /* text-lg */
-    font-weight: 500; /* font-medium */
+    width: 100%;
+    font-size: 1.125rem;
+    font-weight: 500;
 }
 
-@media (min-width: 768px) { /* md breakpoint */
-    .nav-links {
-        flex-direction: row; /* md:flex-row */
-        gap: 2rem; /* md:space-x-8 */
-    }
+.nav-links.open {
+    display: flex;
 }
 
 .nav-links li {
-    margin-bottom: 0.75rem; /* space-y-3 */
-}
-
-@media (min-width: 768px) { /* md breakpoint */
-    .nav-links li {
-        margin-bottom: 0; /* md:space-y-0 */
-    }
+    width: 100%;
+    text-align: center;
 }
 
 .nav-links a {
     color: inherit;
     text-decoration: none;
-    padding-bottom: 0.25rem; /* pb-1 */
-    border-bottom: 2px solid transparent; /* border-b-2 border-transparent */
-    transition: all 0.3s ease-in-out; /* transition duration-300 ease-in-out */
+    display: inline-block;
+    padding-bottom: 0.25rem;
+    border-bottom: 2px solid transparent;
+    transition: color 0.3s ease, border-color 0.3s ease;
 }
 
-.nav-links a:hover {
-    color: #bfdbfe; /* hover:text-blue-200 */
-    border-color: #bfdbfe; /* hover:border-blue-200 */
+.nav-links a:hover,
+.nav-links a:focus-visible {
+    color: #bfdbfe;
+    border-color: #bfdbfe;
 }
 
 .logo-image {
-    max-width: 80px; /* Tamaño máximo inicial más pequeño para el logo */
-    height: auto; /* Mantiene la proporción de la imagen */
-    display: block; /* Elimina el espacio extra debajo de la imagen */
-    margin: 0 auto; /* Centra la imagen si está en un bloque */
-    border-radius: 0.5rem; /* Bordes ligeramente redondeados */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Sombra sutil */
-    transition: transform 0.3s ease-in-out; /* Transición suave para efectos de hover */
+    max-width: 80px;
+    height: auto;
+    display: block;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease-in-out;
 }
 
-/* Efecto al pasar el ratón */
 .logo-image:hover {
-    transform: scale(1.05); /* Ligeramente más grande al pasar el ratón */
+    transform: scale(1.05);
 }
 
-/* Responsividad: Ajustes para pantallas más grandes */
-@media (min-width: 768px) { /* Para pantallas medianas y superiores */
+@media (min-width: 768px) {
+    .menu-toggle {
+        display: none;
+    }
+
+    .nav-links {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 2rem;
+        width: auto;
+    }
+
+    .nav-links li {
+        width: auto;
+    }
+
     .logo-image {
-        max-width: 100px; /* Un poco más grande en desktop */
+        max-width: 100px;
     }
 }
 
-@media (min-width: 1024px) { /* Para pantallas grandes y superiores */
+@media (min-width: 1024px) {
     .logo-image {
-        max-width: 120px; /* Aún más grande en pantallas muy grandes */
+        max-width: 120px;
     }
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }

--- a/src/app/header/header.html
+++ b/src/app/header/header.html
@@ -1,19 +1,57 @@
 <header class="header">
   <nav class="header-nav" aria-label="Secciones principales">
-    <a class="brand-logo" href="#inicio">
-      <img
-        src="assets/images/Logo_ESPE.png"
-        class="logo-image"
-        alt="Logotipo de Germán Cáceres"
-        loading="lazy"
-        decoding="async"
-      />
-    </a>
-    <ul class="nav-links">
-      <li><a href="#inicio">Inicio</a></li>
-      <li><a href="#habilidades">Habilidades</a></li>
-      <li><a href="#proyectos">Proyectos</a></li>
-      <li><a href="#contacto">Contacto</a></li>
+    <div class="brand-area">
+      <a class="brand-logo" href="#inicio">
+        <img
+          [src]="logoImage"
+          class="logo-image"
+          [alt]="logoAlt"
+          loading="lazy"
+          decoding="async"
+        />
+      </a>
+      <button
+        type="button"
+        class="menu-toggle"
+        [attr.aria-expanded]="isMenuOpen"
+        [attr.aria-label]="isMenuOpen ? 'Cerrar menú de navegación' : 'Abrir menú de navegación'"
+        (click)="toggleMenu()"
+      >
+        <span class="sr-only">
+          {{ isMenuOpen ? 'Cerrar menú de navegación' : 'Abrir menú de navegación' }}
+        </span>
+        <svg
+          *ngIf="!isMenuOpen; else closeIcon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 6h16M4 12h16M4 18h16"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+        <ng-template #closeIcon>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M6 6l12 12M6 18L18 6"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-width="2"
+            />
+          </svg>
+        </ng-template>
+      </button>
+    </div>
+    <ul class="nav-links" [class.open]="isMenuOpen">
+      <li><a href="#inicio" (click)="closeMenu()">Inicio</a></li>
+      <li><a href="#habilidades" (click)="closeMenu()">Habilidades</a></li>
+      <li><a href="#proyectos" (click)="closeMenu()">Proyectos</a></li>
+      <li><a href="#contacto" (click)="closeMenu()">Contacto</a></li>
     </ul>
   </nav>
 </header>

--- a/src/app/header/header.ts
+++ b/src/app/header/header.ts
@@ -11,4 +11,13 @@ import { Component } from '@angular/core';
 export class Header {
   protected readonly logoImage = 'assets/images/Logo_ESPE.png';
   protected readonly logoAlt = 'Logotipo de la Universidad de las Fuerzas Armadas ESPE';
+  protected isMenuOpen = false;
+
+  protected toggleMenu(): void {
+    this.isMenuOpen = !this.isMenuOpen;
+  }
+
+  protected closeMenu(): void {
+    this.isMenuOpen = false;
+  }
 }


### PR DESCRIPTION
## Summary
- add a mobile-friendly hamburger toggle to the header navigation
- refine responsive styling for the logo and navigation layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5dfde05d483249fa5720abeb934eb